### PR TITLE
internal/renderer: Do not wrap value text

### DIFF
--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -22,6 +22,7 @@ func (r *TableRenderer) Render(result *bigquery.Result) (string, error) {
 
 	table := tablewriter.NewWriter(&b)
 	table.SetAutoFormatHeaders(false)
+	table.SetAutoWrapText(false)
 	table.SetHeader(result.Keys)
 
 	for _, r := range result.Rows {


### PR DESCRIPTION
I don't want to wrap the result value when the value is long.