### PR TITLE
screen: Enable Emacs-like cursor navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## TODO
 
 - [x] First interactive UI (<kbd>Ctrl</kbd>+<kbd>X</kbd> -> <kbd>Enter</kbd>)
-- [ ] Emacs keybinds (Ctrl-F,B,N,P,A,E,D)
+- [x] Emacs keybinds (Ctrl-F,B,N,P,A,E,D)
 - [x] Dry run (<kbd>Ctrl</kbd>+<kbd>X</kbd> -> <kbd>D</kbd>)
 - [ ] JSON output
 - [ ] Query history

--- a/internal/screen/screen.go
+++ b/internal/screen/screen.go
@@ -133,7 +133,20 @@ func (s *Screen) Run(ctx context.Context) error {
 
 			return nil
 		} else {
-			if event.Key() == tcell.KeyCtrlX {
+			switch event.Key() {
+			case tcell.KeyCtrlB:
+				return tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModNone)
+
+			case tcell.KeyCtrlF:
+				return tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone)
+
+			case tcell.KeyCtrlN:
+				return tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone)
+
+			case tcell.KeyCtrlP:
+				return tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone)
+
+			case tcell.KeyCtrlX:
 				s.ctrlXMode = true
 				s.ctrlXTextView.SetText("Ctrl-X")
 


### PR DESCRIPTION
Some of key bindings like C-a, C-e are already implemented in [`tview.TextArea`](https://github.com/rivo/tview/blob/822bd067b165d14be2d402503c4ce16b7c49279a/textarea.go#L109-L110).