### PR TITLE
page: Put cursor at the beginning of query at startup

### DIFF
--- a/internal/screen/page/query.go
+++ b/internal/screen/page/query.go
@@ -135,7 +135,7 @@ func (q *Query) Init() error {
 		// ignore error
 		query = ""
 	}
-	q.textArea.SetText(query, true)
+	q.textArea.SetText(query, false)
 
 	q.bindKeys()
 


### PR DESCRIPTION
The cursor is currently put at the end of query when `bqc` was launched. However, it results to show only the last line of query in the page, which is fairly inconvenient.